### PR TITLE
Created a demo of setting vars in LHS

### DIFF
--- a/src/main/java/diet/Meal.java
+++ b/src/main/java/diet/Meal.java
@@ -1,0 +1,32 @@
+package diet;
+
+public class Meal {
+
+    private int calories;
+    private int dietClubPoints;
+
+    public Meal() {
+    }
+
+    public Meal(int calories, int dietClubPoints) {
+        this.calories = calories;
+        this.dietClubPoints = dietClubPoints;
+    }
+
+    public int getCalories() {
+        return calories;
+    }
+
+    public void setCalories(int calories) {
+        this.calories = calories;
+    }
+
+    public int getDietClubPoints() {
+        return dietClubPoints;
+    }
+
+    public void setDietClubPoints(int dietClubPoints) {
+        this.dietClubPoints = dietClubPoints;
+    }
+
+}

--- a/src/main/java/diet/MealTooBigWarning.java
+++ b/src/main/java/diet/MealTooBigWarning.java
@@ -1,0 +1,19 @@
+package diet;
+
+public class MealTooBigWarning {
+
+    private String message;
+
+    public MealTooBigWarning(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+}

--- a/src/main/java/uk/co/scattercode/drools/util/DroolsTestUtil.java
+++ b/src/main/java/uk/co/scattercode/drools/util/DroolsTestUtil.java
@@ -1,0 +1,76 @@
+package uk.co.scattercode.drools.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.InvocationTargetException;
+
+import uk.co.scattercode.beans.BeanPropertyFilter;
+
+public class DroolsTestUtil {
+
+    protected static final FactFinder factFinder = new FactFinder();
+
+    /**
+     * This class provides static methods, so we prevent instantiation.
+     */
+    private DroolsTestUtil() {
+    }
+
+    /**
+     * The test will fail if any of the named rules could not be found in the
+     * list of activations.
+     * 
+     * @param ruleNames
+     *            A list of names of rules to look for.
+     */
+    public static void assertRuleFired(KnowledgeEnvironment kenv, String... ruleNames) {
+        for (String ruleName : ruleNames) {
+            assertTrue("Rule [" + ruleName + "] should have fired.", 
+                    DroolsUtil.ruleFired(
+                            kenv.findActivations(), 
+                            ruleName));
+        }
+    }
+
+    /**
+     * The test will fail if any of the named rules fired.
+     * 
+     * @param ruleNames A list of names of rules to look for.
+     */
+    public static void assertRuleNotFired(KnowledgeEnvironment kenv, String... ruleNames) {
+        for (String ruleName : ruleNames) {
+            assertFalse("Rule [" + ruleName + "] should not have fired.", 
+                    DroolsUtil.ruleFired(
+                            kenv.findActivations(), 
+                            ruleName));
+        }
+    }
+
+    /**
+     * A more complex assertion that a fact of the expected class with specified
+     * properties is in working memory.
+     * 
+     * @param factName
+     *            The simple name of the class of the fact we're looking for.
+     * @param expectedProperties
+     *            A sequence of expected property name/value pairs.
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     * @throws NoSuchMethodException
+     */
+    public static void assertFactIsInWorkingMemory(KnowledgeEnvironment kenv, final String factClass, BeanPropertyFilter... expectedProperties) {
+        assertTrue(factFinder.findFacts(
+                kenv, 
+                factClass, 
+                expectedProperties).size() > 0);
+    }
+
+    public static void assertFactNotInWorkingMemory(KnowledgeEnvironment kenv, final String factClass, BeanPropertyFilter... expectedProperties) {
+        assertTrue(factFinder.findFacts(
+                kenv, 
+                factClass, 
+                expectedProperties).size() == 0);
+    }
+
+}

--- a/src/main/java/uk/co/scattercode/drools/util/FactFinder.java
+++ b/src/main/java/uk/co/scattercode/drools/util/FactFinder.java
@@ -1,0 +1,76 @@
+package uk.co.scattercode.drools.util;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.drools.runtime.ObjectFilter;
+import org.drools.runtime.StatefulKnowledgeSession;
+import org.drools.runtime.rule.FactHandle;
+
+import uk.co.scattercode.beans.BeanMatcher;
+import uk.co.scattercode.beans.BeanPropertyFilter;
+
+public class FactFinder {
+
+    BeanMatcher beanMatcher = new BeanMatcher();
+
+    /**
+     * An assertion that a fact of the expected class with specified properties
+     * is in working memory.
+     * 
+     * @param kenv
+     *            A {@link KnowledgeEnvironment} containing a
+     *            {@link KnowledgeSession} in which we are looking for the fact.
+     * @param factClass
+     *            The simple name of the class of the fact we're looking for.
+     * @param expectedProperties
+     *            A sequence of expected property name/value pairs.
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     * @throws NoSuchMethodException
+     */
+    public Collection<Object> findFacts(final KnowledgeEnvironment kenv,
+            final String factClass,
+            final BeanPropertyFilter... expectedProperties) {
+        return findFacts(kenv.getKnowledgeSession(), factClass, expectedProperties);
+    }
+
+    /**
+     * An assertion that a fact of the expected class with specified properties
+     * is in working memory.
+     * 
+     * @param session
+     *            A {@link KnowledgeSession} in which we are looking for the
+     *            fact.
+     * @param factClass
+     *            The simple name of the class of the fact we're looking for.
+     * @param expectedProperties
+     *            A sequence of expected property name/value pairs.
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     * @throws NoSuchMethodException
+     */
+    public Collection<Object> findFacts(final StatefulKnowledgeSession session,
+            final String factClass,
+            final BeanPropertyFilter... expectedProperties) {
+
+        ObjectFilter filter = new ObjectFilter() {
+            @Override
+            public boolean accept(Object object) {
+                return object.getClass().getSimpleName().equals(factClass);
+            }
+        };
+
+        Collection<FactHandle> factHandles = session.getFactHandles(filter);
+        Collection<Object> facts = new ArrayList<Object>();
+        for (FactHandle handle : factHandles) {
+            Object fact = session.getObject(handle);
+            if (beanMatcher.matches(fact, expectedProperties)) {
+                facts.add(fact);
+            }
+        }
+        return facts;
+    }
+
+}

--- a/src/main/resources/rules/diet.drl
+++ b/src/main/resources/rules/diet.drl
@@ -1,0 +1,9 @@
+package diet
+
+rule "Warn when my meal is too large"
+when
+    $meal: Meal($calories: calories > 1000)
+    $unit: String() from "calories"
+then
+    insert(new MealTooBigWarning("That meal will push you over your 1000 " + $unit + " limit for today."));
+end

--- a/src/main/resources/rules/diet.dsl
+++ b/src/main/resources/rules/diet.dsl
@@ -1,0 +1,2 @@
+[when][]I am given a meal of more than "{sizeLimit}" "{unit}" = $meal: Meal($size: {unit} > {sizeLimit}); $sizeLimit: Integer() from {sizeLimit}; $unit: String() from "{unit}"
+[then][]Warn that the meal is too big = insertLogical(new MealTooBigWarning("That meal is bigger than your " + $sizeLimit + " " + $unit + " meal limit."));

--- a/src/main/resources/rules/diet.dslr
+++ b/src/main/resources/rules/diet.dslr
@@ -1,0 +1,15 @@
+package diet
+
+rule "Warn when my meal has too many calories"
+when
+    I am given a meal of more than "1000" "calories"
+then
+    Warn that the meal is too big
+end
+
+rule "Warn when my meal has too many diet club points"
+when
+    I am given a meal of more than "11" "dietClubPoints"
+then
+    Warn that the meal is too big
+end

--- a/src/test/java/diet/MealLimitTest.java
+++ b/src/test/java/diet/MealLimitTest.java
@@ -1,0 +1,39 @@
+package diet;
+
+import static org.junit.Assert.*;
+import static org.drools.builder.ResourceType.*;
+import static uk.co.scattercode.drools.util.ResourcePathType.*;
+
+import org.junit.Test;
+
+import uk.co.scattercode.drools.util.DroolsResource;
+import uk.co.scattercode.drools.util.DroolsTestUtil;
+import uk.co.scattercode.drools.util.KnowledgeEnvironment;
+
+public class MealLimitTest {
+
+    private KnowledgeEnvironment kenv = new KnowledgeEnvironment(
+            new DroolsResource[] {
+                    //new DroolsResource("rules/diet.drl", CLASSPATH, DRL),
+                    new DroolsResource("rules/diet.dsl", CLASSPATH, DSL),
+                    new DroolsResource("rules/diet.dslr", CLASSPATH, DSLR) });
+
+    /**
+     * Running this test will cause the DRL and DSLR to compile.
+     */
+    @Test
+    public void shouldCompile() {
+    }
+
+    @Test
+    public void shouldCheckLimits() throws InstantiationException, IllegalAccessException {
+        Meal meal = new Meal(1500, 13);
+        
+        kenv.insert(meal);
+        kenv.fireAllRules();
+        DroolsTestUtil.assertRuleFired(kenv, "Warn when my meal is too large");
+        DroolsTestUtil.assertRuleFired(kenv, "Warn when my meal has too many calories");
+        DroolsTestUtil.assertRuleFired(kenv, "Warn when my meal has too many diet club points");
+    }
+
+}


### PR DESCRIPTION
I just couldn't find any examples of the DRL syntax for 'creating' a value like that in the LHS. A quick test with a contrived little example shows me that the following works:

rule "Warn when my meal is too large"
when
    $meal: Meal($calories: calories > 1000)
    $unit: String() from "calories"
then
    insert(new MealTooBigWarning("That meal is bigger than your 1000 " + $unit + " limit."));
end

So, based on that I'm able to write a DSL like this:

[when][]I am given a meal of more than "{sizeLimit}" "{unit}" = $meal: Meal($size: {unit} > {sizeLimit}); $sizeLimit: Integer() from {sizeLimit}; $unit: String() from "{unit}"
[then][]Warn that the meal is too big = insertLogical(new MealTooBigWarning("That meal is bigger than your " + $sizeLimit + " " + $unit + " meal limit."));

Which means that I can write DSLR like this:

rule "Warn when my meal has too many calories"
when
    I am given a meal of more than "1000" "calories"
then
    Warn that the meal is too big
end

… which gives me:

That meal is bigger than your 1000 calories meal limit.

Or this:

rule "Warn when my meal has too many diet club points"
when
    I am given a meal of more than "11" "dietClubPoints"
then
    Warn that the meal is too big
end

… which gives me:

That meal is bigger than your 11 dietClubPoints meal limit.

So I can define an enumeration:

'MealSize.units': ['calories=calories', 'dietClubPoints=diet club points']

So that in Guvnor, I have a single sentence with a drop-down menu containing the options "calories" and "diet club points". That keeps things nice and clean for the users.
